### PR TITLE
feat: docker install openjdk-8-jdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/go,c++,macos,windows,linux
 bin
+
+parsley-core/*

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 LABEL maintainer="jungnoh.dev@gmail.com"
 
-RUN apt-get update -y && apt-get install -y make
+RUN apt-get update -y && apt-get install -y make openjdk-8-jdk
 ADD Makefile /src/Makefile
 WORKDIR /src
 RUN make ubuntu-deps


### PR DESCRIPTION
+ java 실행을 위해 openjdk-8-jdk 를 설치합니다.